### PR TITLE
Initial implementation of addon

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,8 @@
+{
+  "presets": [
+    "es2015"
+  ],
+  "plugins": [
+    "add-module-exports"
+  ]
+}

--- a/addon-test-support/helpers/with-variation.js
+++ b/addon-test-support/helpers/with-variation.js
@@ -1,0 +1,8 @@
+import Ember from 'ember';
+
+export function withVariation(app, key, value = true) {
+  let launchDarkly = app.__container__.lookup('service:launch-darkly');
+  launchDarkly.variation(key, value);
+}
+
+Ember.Test.registerHelper('withVariation', withVariation);

--- a/addon/helpers/variation.js
+++ b/addon/helpers/variation.js
@@ -1,0 +1,33 @@
+import Helper from 'ember-helper';
+import service from 'ember-service/inject';
+import { assert } from 'ember-metal/utils';
+
+export default Helper.extend({
+  launchDarkly: service(),
+
+  compute([key]) {
+    let service = this.get('launchDarkly');
+
+    assert(`Unknown feature flag specified: ${key}`, service.allFlags().hasOwnProperty(key));
+
+    if (this._key) {
+      service.removeObserver(this._key, this, 'recompute');
+    }
+
+    this._key = key;
+    service.addObserver(key, this, 'recompute');
+
+    return service.get(key);
+  },
+
+  destroy() {
+    let service = this.get('launchDarkly');
+
+    if (this._key) {
+      service.removeObserver(this._key, this, 'recompute');
+    }
+
+    return this._super();
+  }
+});
+

--- a/addon/initializers/launch-darkly.js
+++ b/addon/initializers/launch-darkly.js
@@ -1,0 +1,23 @@
+import RemoteService from 'ember-launch-darkly/services/launch-darkly-remote';
+import LocalService from 'ember-launch-darkly/services/launch-darkly-local';
+import { assign } from 'ember-platform';
+
+export function initialize(application) {
+  let appConfig = application.resolveRegistration('config:environment') || {};
+
+  const defaults = {
+    local: appConfig.environment !== 'production'
+  };
+
+  let config = appConfig.launchDarkly || {};
+  config = assign({}, defaults, config);
+
+  let Factory = config.local ? LocalService : RemoteService;
+
+  application.register('service:launch-darkly', Factory);
+}
+
+export default {
+  name: 'launch-darkly',
+  initialize: initialize
+};

--- a/addon/instance-initializers/expose-local-launch-darkly.js
+++ b/addon/instance-initializers/expose-local-launch-darkly.js
@@ -1,0 +1,23 @@
+import { assign } from 'ember-platform';
+
+export function initialize(appInstance) {
+  let appConfig = appInstance.resolveRegistration('config:environment') || {};
+
+  const defaults = {
+    local: appConfig.environment !== 'production'
+  };
+
+  let config = appConfig.launchDarkly || {};
+  config = assign({}, defaults, config);
+
+  if (config.local) {
+    let client = appInstance.lookup('service:launch-darkly');
+    window.ld = client;
+  }
+}
+
+export default {
+  name: 'expose-local-launch-darkly',
+  initialize: initialize
+};
+

--- a/addon/lib/null-client.js
+++ b/addon/lib/null-client.js
@@ -1,0 +1,12 @@
+export default {
+  initialize() {},
+  identify(_user, _hash, cb) {
+    cb();
+  },
+  allFlags() {
+    return {};
+  },
+  variation() {
+    return false;
+  }
+}

--- a/addon/services/launch-darkly-local.js
+++ b/addon/services/launch-darkly-local.js
@@ -1,17 +1,79 @@
 import Service from 'ember-service';
 import getOwner from 'ember-owner/get';
 import RSVP from 'rsvp';
+import { warn } from 'ember-debug';
+import EmberObject from 'ember-object';
+import computed from 'ember-computed';
+import Ember from 'ember';
 
 export default Service.extend({
-  initialize(user) {
-    let config = this._config();
+  _allFlags: null,
+  _user: null,
 
-    console.log('LOCAL', config);
+  init() {
+    this._super(...arguments);
+
+    let { featureFlags } = this._config();
+    featureFlags = featureFlags || {}
+
+    if (typeof(featureFlags) !== 'object' || Object.keys(featureFlags).length === 0) {
+      warn('ENV.launchDarkly.featureFlags not specified for local use. Defaulting all feature flags to "false"');
+      this.set('_allFlags', EmberObject.create({}));
+    } else {
+      this.set('_allFlags', EmberObject.create(featureFlags));
+
+      Object.keys(this.allFlags()).forEach(key => {
+        Ember.defineProperty(this, key, computed(() => {
+          return this.get(`_allFlags.${key}`);
+        }));
+      });
+    }
+  },
+
+  initialize(user) {
+    return this.identify(user);
+  },
+
+  identify(user) {
+    this.set('_user', user);
+    return RSVP.resolve();
+  },
+
+  allFlags() {
+    return Object.assign({}, this.get('_allFlags'));
+  },
+
+  variation(key, value) {
+    if (value !== undefined) {
+      return this._setFlag(key, value);
+    }
+
+    return this._getFlag(key);
+  },
+
+  enable(key) {
+    return this._setFlag(key, true);
+  },
+
+  disable(key) {
+    return this._setFlag(key, false);
+  },
+
+  user() {
+    return this.get('_user');
   },
 
   _config() {
     let appConfig = getOwner(this).resolveRegistration('config:environment');
 
     return appConfig.launchDarkly || {};
+  },
+
+  _setFlag(key, value) {
+    return this.set(key, value);
+  },
+
+  _getFlag(key) {
+    return this.get(key);
   }
 });

--- a/addon/services/launch-darkly-local.js
+++ b/addon/services/launch-darkly-local.js
@@ -1,0 +1,17 @@
+import Service from 'ember-service';
+import getOwner from 'ember-owner/get';
+import RSVP from 'rsvp';
+
+export default Service.extend({
+  initialize(user) {
+    let config = this._config();
+
+    console.log('LOCAL', config);
+  },
+
+  _config() {
+    let appConfig = getOwner(this).resolveRegistration('config:environment');
+
+    return appConfig.launchDarkly || {};
+  }
+});

--- a/addon/services/launch-darkly-remote.js
+++ b/addon/services/launch-darkly-remote.js
@@ -1,17 +1,116 @@
 import Service from 'ember-service';
 import getOwner from 'ember-owner/get';
 import RSVP from 'rsvp';
+import { assert } from 'ember-metal/utils';
+import { warn } from 'ember-debug';
+import run from 'ember-runloop';
+import computed from 'ember-computed';
+import Ember from 'ember';
+import EmberObject from 'ember-object';
+
+import NullClient from 'ember-launch-darkly/lib/null-client';
 
 export default Service.extend({
-  initialize(user) {
-    let config = this._config();
+  _client: null,
+  _allFlags: null,
 
-    console.log('REMOTE', config);
+  init() {
+    this._super(...arguments);
+    this.set('_allFlags', EmberObject.create({}));
+  },
+
+  initialize(user = {}/*, options = {}*/) {
+    let { clientSideId } = this._config();
+
+    assert('ENV.launchDarkly.clientSideId must be specified in config/environment.js', clientSideId);
+
+    if (!clientSideId) {
+      warn('ENV.launchDarkly.clientSideId not specified. Defaulting all feature flags to "false"');
+
+      this.set('_client', NullClient);
+
+      return RSVP.resolve();
+    }
+
+    assert('user.key must be specified in initilize payload', user.key);
+
+    if (!user.key) {
+      warn('user.key not specified in initialize payload. Defaulting all feature flags to "false"');
+
+      this.set('_client', NullClient);
+
+      return RSVP.resolve();
+    }
+
+    if (!window.LDClient) {
+      warn('Launch Darkly JS client not found. Defaulting all feature flags to "false"');
+
+      this.set('_client', NullClient);
+
+      return RSVP.resolve();
+    }
+
+    return RSVP.resolve()
+      .then(() => this._initialize(clientSideId, user))
+      .then(() => this._updateLocalFlags())
+      .then(() => this._registerComputedProperties());
+  },
+
+  identify(user) {
+    return RSVP.resolve()
+      .then(() => this._identify(user))
+      .then(() => this._updateLocalFlags());
+  },
+
+  allFlags() {
+    return this.get('_client').allFlags();
+  },
+
+  variation(key) {
+    return this.get('_client').variation(key, false);
   },
 
   _config() {
     let appConfig = getOwner(this).resolveRegistration('config:environment');
 
     return appConfig.launchDarkly || {};
+  },
+
+  _initialize(id, user/*, options*/) {
+    return new RSVP.Promise((resolve, reject) => {
+      let client = window.LDClient.initialize(id, user/*, options*/);
+
+      client.on('ready', () => {
+        this.set('_client', client);
+        run(null, resolve);
+      });
+
+      run.later(this, () => {
+        if (!this.get('_client')) {
+          run(null, reject);
+        }
+      }, 10000);
+    })
+  },
+
+  _updateLocalFlags() {
+    this.get('_allFlags').setProperties(this.allFlags());
+    return RSVP.resolve();
+  },
+
+  _registerComputedProperties() {
+    Object.keys(this.get('_allFlags')).forEach(key => {
+      Ember.defineProperty(this, key, computed(`_allFlags.${key}`, () => {
+        return this.variation(key);
+      }));
+    });
+
+    return RSVP.resolve();
+  },
+
+  _identify(user) {
+    return new RSVP.Promise(resolve => {
+      this.get('_client').identify(user, null, resolve);
+    })
   }
 });

--- a/addon/services/launch-darkly-remote.js
+++ b/addon/services/launch-darkly-remote.js
@@ -1,0 +1,17 @@
+import Service from 'ember-service';
+import getOwner from 'ember-owner/get';
+import RSVP from 'rsvp';
+
+export default Service.extend({
+  initialize(user) {
+    let config = this._config();
+
+    console.log('REMOTE', config);
+  },
+
+  _config() {
+    let appConfig = getOwner(this).resolveRegistration('config:environment');
+
+    return appConfig.launchDarkly || {};
+  }
+});

--- a/addon/services/launch-darkly.js
+++ b/addon/services/launch-darkly.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-launch-darkly/services/launch-darkly-remote';

--- a/app/helpers/variation.js
+++ b/app/helpers/variation.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-launch-darkly/helpers/variation';

--- a/app/initializers/launch-darkly.js
+++ b/app/initializers/launch-darkly.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-launch-darkly/initializers/launch-darkly';

--- a/app/instance-initializers/expose-local-launch-darkly.js
+++ b/app/instance-initializers/expose-local-launch-darkly.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-launch-darkly/instance-initializers/expose-local-launch-darkly';

--- a/index.js
+++ b/index.js
@@ -2,5 +2,9 @@
 'use strict';
 
 module.exports = {
-  name: 'ember-launch-darkly'
+  name: 'ember-launch-darkly',
+
+  isDevelopingAddon() {
+    return true;
+  }
 };

--- a/index.js
+++ b/index.js
@@ -1,10 +1,28 @@
 /* eslint-env node */
 'use strict';
 
+var path = require('path');
+var Funnel = require('broccoli-funnel');
+var MergeTrees = require('broccoli-merge-trees');
+
 module.exports = {
   name: 'ember-launch-darkly',
 
   isDevelopingAddon() {
     return true;
+  },
+
+  included(app) {
+    this._super.included.apply(this, arguments);
+
+    this.import('vendor/ldclient.js');
+  },
+
+  treeForVendor(vendorTree) {
+    var ldTree = new Funnel(path.dirname(require.resolve('ldclient-js/dist/ldclient.js')), {
+      files: ['ldclient.js'],
+    });
+
+    return new MergeTrees([vendorTree, ldTree]);
   }
 };

--- a/index.js
+++ b/index.js
@@ -15,6 +15,16 @@ module.exports = {
   included(app) {
     this._super.included.apply(this, arguments);
 
+    if (!this._registeredWithBabel) {
+      app.options = app.options || {};
+      app.options.babel = app.options.babel || {};
+      app.options.babel.plugins = app.options.babel.plugins || [];
+
+      app.options.babel.plugins.unshift(require('./launch-darkly-variation-helper.js'));
+
+      this._registeredWithBabel = true;
+    }
+
     this.import('vendor/ldclient.js');
   },
 

--- a/launch-darkly-variation-helper.js
+++ b/launch-darkly-variation-helper.js
@@ -1,0 +1,210 @@
+const MODULE_NAME = 'ember-launch-darkly';
+const MEMBER_NAME = 'variation';
+const SERVICE_PROPERTY_NAME = 'launchDarkly';
+const SERVICE_VARIABLE_NAME = 'launchDarkly';
+const SERVICE_INJECTION_FUNCTION_NAME = 'launchDarklyService';
+
+const COMPUTED_MODULE_NAME = 'ember-computed';
+const COMPUTED_DEFAULT_MEMBER_NAME = 'default';
+
+const EMBER_MODULE_NAME = 'ember';
+const EMBER_DEFAULT_MEMBER_NAME = 'default';
+
+function _assertName(path, value) {
+  return path.node.name === value;
+}
+
+module.exports = function launchDarklyVariationHelperPlugin({ types: t }) {
+  return {
+    name: 'launch-darkly-variation-helper',
+    visitor: {
+      Program: {
+        enter(path, state) {
+          let variationImport = _findVariationHelperImport(path, t);
+
+          if (variationImport && _isReferenced(variationImport, t)) {
+            state.variationHelperReferenced = true;
+          }
+        },
+
+        exit(path, state) {
+          let variationImport = _findVariationHelperImport(path, t);
+
+          if (variationImport) {
+            _removeSpecifierOrImport(variationImport, t);
+
+            if (state.variationHelperReferenced) {
+              _insertServiceImport(path, t);
+            }
+          }
+        }
+      },
+
+      Identifier(path, state) {
+        if (path.referencesImport(MODULE_NAME, MEMBER_NAME)) {
+          let parentCallExpression = path.findParent(p => t.isCallExpression(p));
+          let key = parentCallExpression.get('arguments.0').node.value;
+          parentCallExpression.replaceWith(_build(key, t));
+
+          let { parent, type } = _findParent(parentCallExpression, t);
+
+          switch (type) {
+            case 'computed-property': {
+              let dependentKey = `${SERVICE_PROPERTY_NAME}.${key}`;
+
+              if (_shouldInjectDependentKey(key, parent, t)) {
+                parent.node.arguments.unshift(t.stringLiteral(dependentKey));
+              }
+
+              let fn = parent.get('arguments').find(a => t.isFunctionExpression(a));
+
+              if (fn && !_containsServiceDeclaration(fn, t)) {
+                _insertServiceDeclaration(fn, t);
+              }
+
+              return;
+            }
+            case 'function': {
+              _insertServiceDeclaration(parent, t);
+              return;
+            }
+          }
+        }
+      },
+
+      CallExpression(path, state) {
+        if (state.variationHelperReferenced) {
+          _insertServiceInjection(path, t);
+        }
+      }
+    }
+  };
+}
+
+module.exports.baseDir = function() { return __dirname };
+
+function _insertServiceDeclaration(path, t) {
+  path.get('body').unshiftContainer('body', _buildServiceDeclaration(t));
+}
+
+function _findParent(path, t) {
+  let parentComputed = path.findParent(p => {
+    let isComputed = t.isCallExpression(p) && t.isIdentifier(p.get('callee')) && p.get('callee').referencesImport(COMPUTED_MODULE_NAME, COMPUTED_DEFAULT_MEMBER_NAME);
+    let isEmberDotComputed = t.isCallExpression(p) &&
+      t.isMemberExpression(p.get('callee')) &&
+      p.get('callee.object').referencesImport(EMBER_MODULE_NAME, EMBER_DEFAULT_MEMBER_NAME) &&
+      _assertName(p.get('callee.property'), 'computed');
+
+    return isComputed || isEmberDotComputed;
+  });
+
+  if (parentComputed) {
+    return { parent: parentComputed, type: 'computed-property' }
+  }
+
+  let parentObjectMethod = path.findParent(p => t.isObjectMethod(p) || t.isFunctionExpression(p));
+
+  if (parentObjectMethod) {
+    return { parent: parentObjectMethod, type: 'function' };
+  }
+}
+
+function _buildServiceDeclaration(t) {
+  let memberExpression = t.memberExpression(t.thisExpression(), t.identifier('get'));
+  let callExpression = t.callExpression(memberExpression, [t.stringLiteral(SERVICE_PROPERTY_NAME)]);
+  let variableDeclarator = t.variableDeclarator(t.identifier(SERVICE_VARIABLE_NAME), callExpression);
+  return t.variableDeclaration('const', [variableDeclarator]);
+}
+
+function _findVariationHelperImport(path, t) {
+  return path.get('body')
+    .filter(obj => t.isImportDeclaration(obj))
+    .find(obj => _isVariationImport(obj, t));
+}
+
+function _importSpecifier(path, t) {
+  return path.get('specifiers')
+    .find(obj => t.isImportSpecifier(obj) && _assertName(obj.get('imported'), MEMBER_NAME));
+}
+
+function _isVariationImport(path, t) {
+  if (path.get('source').node.value === MODULE_NAME) {
+    let specifier = _importSpecifier(path, t);
+
+    return !!specifier;
+  }
+}
+
+function _isReferenced(path, t) {
+  let specifier = _importSpecifier(path, t);
+  let localName = specifier.get('local').node.name;
+  return specifier.scope.bindings[localName].references > 0;
+}
+
+function _removeSpecifierOrImport(path, t) {
+  if (path.get('specifiers').length > 1) {
+    _importSpecifier(path, t).remove();
+  } else {
+    path.remove();
+  }
+}
+
+function _insertServiceImport(path, t) {
+  path.unshiftContainer('body', _buildServiceImport(t));
+}
+
+function _buildServiceImport(t) {
+  var specifier = t.importSpecifier(t.identifier(SERVICE_INJECTION_FUNCTION_NAME), t.identifier('default'));
+  return t.importDeclaration([specifier], t.stringLiteral('ember-service/inject'));
+}
+
+function _insertServiceInjection(path, t) {
+  let callee = path.get('callee');
+
+  if (t.isMemberExpression(callee)) {
+    let property = callee.get('property');
+
+    if (t.isIdentifier(property) && _assertName(property, 'extend')) {
+      let object = path.get('arguments').find(arg => t.isObjectExpression(arg));
+
+      if (object) {
+        object.unshiftContainer('properties', _buildServiceInjection(t));
+      }
+    }
+  }
+}
+
+function _buildServiceInjection(t) {
+  return t.objectProperty(t.identifier(SERVICE_PROPERTY_NAME), t.callExpression(t.identifier(SERVICE_INJECTION_FUNCTION_NAME), []));
+}
+
+
+function _containsServiceDeclaration(path, t) {
+  let declaration = path.get('body.body')
+    .filter(a => t.isVariableDeclaration(a))
+    .find(a => {
+      return _assertName(a.get('declarations.0.id'), SERVICE_VARIABLE_NAME);
+    })
+
+  return !!declaration;
+}
+
+function _shouldInjectDependentKey(key, path, t) {
+  let found = path.get('arguments').find(a => {
+    return t.isStringLiteral(a) && _containsDependentKey(key, a.node.value);
+  });
+
+  return !found;
+}
+
+function _containsDependentKey(key, value) {
+  const regex = new RegExp(`${SERVICE_PROPERTY_NAME}\.\{(.*)\}`);
+  let matches = value.match(regex);
+
+  return (matches && matches[1] && matches[1].split(',').map(s => s.trim()).includes(key)) ||
+    value === `${SERVICE_PROPERTY_NAME}.${key}`;
+}
+
+function _build(key, t) {
+  return t.callExpression(t.memberExpression(t.identifier(SERVICE_VARIABLE_NAME), t.identifier('get')), [t.stringLiteral(key)]);
+}

--- a/nodetests/__fixtures__/helper-invocations/expected.js
+++ b/nodetests/__fixtures__/helper-invocations/expected.js
@@ -1,0 +1,183 @@
+import { default as launchDarklyService } from 'ember-service/inject';
+import Component from 'ember-component';
+import computed from 'ember-computed';
+
+import foo from 'foo';
+
+import bar from 'bar';
+
+import Ember from 'ember';
+
+export default Component.extend({
+  launchDarkly: launchDarklyService(),
+
+  price: computed('launchDarkly.apply-discount', 'price', function () {
+    const launchDarkly = this.get('launchDarkly');
+
+    if (launchDarkly.get('apply-discount')) {
+      return this.get('price') * 0.5;
+    }
+
+    return this.get('price');
+  }),
+
+  foo: computed('launchDarkly.apply-discount', function () {
+    const launchDarkly = this.get('launchDarkly');
+
+    if (launchDarkly.get('apply-discount')) {
+      return this.get('price') * 0.5;
+    }
+
+    return this.get('price');
+  }),
+
+  bar: computed('launchDarkly.apply-discount', function () {
+    const launchDarkly = this.get('launchDarkly');
+
+    if (launchDarkly.get('apply-discount')) {
+      return this.get('price') * 0.5;
+    }
+
+    return this.get('price');
+  }),
+
+  baz: computed('launchDarkly.apply-discount', 'launchDarkly.new-login', function () {
+    const launchDarkly = this.get('launchDarkly');
+
+    if (launchDarkly.get('apply-discount')) {
+      return this.get('price') * 0.5;
+    }
+
+    return this.get('price');
+  }),
+
+  boo: computed('launchDarkly.{new-login,apply-discount}', function () {
+    const launchDarkly = this.get('launchDarkly');
+
+    if (launchDarkly.get('apply-discount')) {
+      return this.get('price') * 0.5;
+    }
+
+    return this.get('price');
+  }),
+
+  bop: computed('launchDarkly.apply-discount', 'launchDarkly.{new-login,new-logout}', function () {
+    const launchDarkly = this.get('launchDarkly');
+
+    if (launchDarkly.get('apply-discount')) {
+      return this.get('price') * 0.5;
+    }
+
+    return this.get('price');
+  }),
+
+  yetAnotherPrice: Ember.computed('launchDarkly.apply-discount', 'price', function () {
+    const launchDarkly = this.get('launchDarkly');
+
+    if (launchDarkly.get('apply-discount')) {
+      return this.get('price') * 0.5;
+    }
+
+    return this.get('price');
+  }),
+
+  ben: Ember.computed('launchDarkly.apply-discount', function () {
+    const launchDarkly = this.get('launchDarkly');
+
+    if (launchDarkly.get('apply-discount')) {
+      return this.get('price') * 0.5;
+    }
+
+    return this.get('price');
+  }),
+
+  bon: Ember.computed('launchDarkly.apply-discount', function () {
+    const launchDarkly = this.get('launchDarkly');
+
+    if (launchDarkly.get('apply-discount')) {
+      return this.get('price') * 0.5;
+    }
+
+    return this.get('price');
+  }),
+
+  ban: Ember.computed('launchDarkly.apply-discount', 'launchDarkly.new-login', function () {
+    const launchDarkly = this.get('launchDarkly');
+
+    if (launchDarkly.get('apply-discount')) {
+      return this.get('price') * 0.5;
+    }
+
+    return this.get('price');
+  }),
+
+  bin: Ember.computed('launchDarkly.{new-login,apply-discount}', function () {
+    const launchDarkly = this.get('launchDarkly');
+
+    if (launchDarkly.get('apply-discount')) {
+      return this.get('price') * 0.5;
+    }
+
+    return this.get('price');
+  }),
+
+  bun: Ember.computed('launchDarkly.apply-discount', 'launchDarkly.{new-login,new-logout}', function () {
+    const launchDarkly = this.get('launchDarkly');
+
+    if (launchDarkly.get('apply-discount')) {
+      return this.get('price') * 0.5;
+    }
+
+    return this.get('price');
+  }),
+
+  goo: computed('launchDarkly.baz', 'launchDarkly.bar', function () {
+    const launchDarkly = this.get('launchDarkly');
+
+    if (launchDarkly.get('bar') || launchDarkly.get('baz')) {
+      return null;
+    }
+  }),
+
+  gar: computed('launchDarkly.bar', function () {
+    const launchDarkly = this.get('launchDarkly');
+
+    return EmberObject.create({
+      bar() {
+        if (launchDarkly.get('bar')) {
+          return null;
+        }
+      }
+    });
+  }),
+
+  otherPrice() {
+    const launchDarkly = this.get('launchDarkly');
+
+    if (launchDarkly.get('apply-discount')) {
+      return this.get('price') * 0.5;
+    }
+
+    return this.get('price');
+  },
+
+  yar: function () {
+    const launchDarkly = this.get('launchDarkly');
+
+    if (launchDarkly.get('apply-discount')) {
+      return this.get('price') * 0.5;
+    }
+
+    return this.get('price');
+  },
+
+  mar: task(function* () {
+    const launchDarkly = this.get('launchDarkly');
+
+    if (launchDarkly.get('apply-discount')) {
+      return this.get('price') * 0.5;
+    }
+
+    return this.get('price');
+  })
+});

--- a/nodetests/__fixtures__/helper-invocations/input.js
+++ b/nodetests/__fixtures__/helper-invocations/input.js
@@ -1,0 +1,146 @@
+import Component from 'ember-component';
+import computed from 'ember-computed';
+
+import foo from 'foo';
+import { variation } from 'ember-launch-darkly';
+import bar from 'bar';
+
+import Ember from 'ember';
+
+export default Component.extend({
+  price: computed('price', function () {
+    if (variation('apply-discount')) {
+      return this.get('price') * 0.5;
+    }
+
+    return this.get('price');
+  }),
+
+  foo: computed(function () {
+    if (variation('apply-discount')) {
+      return this.get('price') * 0.5;
+    }
+
+    return this.get('price');
+  }),
+
+  bar: computed('launchDarkly.apply-discount', function () {
+    if (variation('apply-discount')) {
+      return this.get('price') * 0.5;
+    }
+
+    return this.get('price');
+  }),
+
+  baz: computed('launchDarkly.new-login', function () {
+    if (variation('apply-discount')) {
+      return this.get('price') * 0.5;
+    }
+
+    return this.get('price');
+  }),
+
+  boo: computed('launchDarkly.{new-login,apply-discount}', function () {
+    if (variation('apply-discount')) {
+      return this.get('price') * 0.5;
+    }
+
+    return this.get('price');
+  }),
+
+  bop: computed('launchDarkly.{new-login,new-logout}', function () {
+    if (variation('apply-discount')) {
+      return this.get('price') * 0.5;
+    }
+
+    return this.get('price');
+  }),
+
+  yetAnotherPrice: Ember.computed('price', function () {
+    if (variation('apply-discount')) {
+      return this.get('price') * 0.5;
+    }
+
+    return this.get('price');
+  }),
+
+  ben: Ember.computed(function () {
+    if (variation('apply-discount')) {
+      return this.get('price') * 0.5;
+    }
+
+    return this.get('price');
+  }),
+
+  bon: Ember.computed('launchDarkly.apply-discount', function () {
+    if (variation('apply-discount')) {
+      return this.get('price') * 0.5;
+    }
+
+    return this.get('price');
+  }),
+
+  ban: Ember.computed('launchDarkly.new-login', function () {
+    if (variation('apply-discount')) {
+      return this.get('price') * 0.5;
+    }
+
+    return this.get('price');
+  }),
+
+  bin: Ember.computed('launchDarkly.{new-login,apply-discount}', function () {
+    if (variation('apply-discount')) {
+      return this.get('price') * 0.5;
+    }
+
+    return this.get('price');
+  }),
+
+  bun: Ember.computed('launchDarkly.{new-login,new-logout}', function () {
+    if (variation('apply-discount')) {
+      return this.get('price') * 0.5;
+    }
+
+    return this.get('price');
+  }),
+
+  goo: computed(function() {
+    if(variation('bar') || variation('baz')) {
+      return null;
+    }
+  }),
+
+  gar: computed(function() {
+    return EmberObject.create({
+      bar() {
+        if(variation('bar')) {
+          return null;
+        }
+      }
+    });
+  }),
+
+  otherPrice() {
+    if (variation('apply-discount')) {
+      return this.get('price') * 0.5;
+    }
+
+    return this.get('price');
+  },
+
+  yar: function() {
+    if (variation('apply-discount')) {
+      return this.get('price') * 0.5;
+    }
+
+    return this.get('price');
+  },
+
+  mar: task(function* () {
+    if (variation('apply-discount')) {
+      return this.get('price') * 0.5;
+    }
+
+    return this.get('price');
+  })
+});

--- a/nodetests/launch-darkly-variation-helper-plugin-test.js
+++ b/nodetests/launch-darkly-variation-helper-plugin-test.js
@@ -1,0 +1,239 @@
+import pluginTester from 'babel-plugin-tester';
+import plugin from '../launch-darkly-variation-helper';
+
+pluginTester({
+  plugin,
+  title: 'Import transformations',
+  snapshot: false,
+  tests: [
+    {
+      title: 'Single import',
+      code: `
+      import foo from 'foo';
+      import { variation } from 'ember-launch-darkly';
+      `,
+      output: `
+      import foo from 'foo';
+      `
+    },
+    {
+      title: 'Multiple imports',
+      code: `
+      import foo from 'foo';
+      import { bar, variation, baz } from 'ember-launch-darkly';
+      `,
+      output: `
+      import foo from 'foo';
+      import { bar, baz } from 'ember-launch-darkly';
+      `
+    },
+    {
+      title: 'Single import (aliased)',
+      code: `
+      import foo from 'foo';
+      import { variation as v } from 'ember-launch-darkly';
+      `,
+      output: `import foo from 'foo';`
+    },
+    {
+      title: 'Multiple imports (aliased)',
+      code: `
+      import foo from 'foo';
+      import { bar, variation as v, baz } from 'ember-launch-darkly';
+      `,
+      output: `
+      import foo from 'foo';
+      import { bar, baz } from 'ember-launch-darkly';
+      `
+    }
+  ]
+});
+
+pluginTester({
+  plugin,
+  title: 'Launch Darkly service injection',
+  snapshot: false,
+  tests: [
+    {
+      title: 'Export inline object as default',
+      code: `
+      import computed from 'ember-computed';
+      import { variation } from 'ember-launch-darkly';
+
+      export default Component.extend({
+        foo: computed(function() {
+          if(variation('bar')) {
+            return null;
+          }
+        })
+      });
+      `,
+      output: `
+      import { default as launchDarklyService } from 'ember-service/inject';
+      import computed from 'ember-computed';
+
+
+      export default Component.extend({
+        launchDarkly: launchDarklyService(),
+
+        foo: computed('launchDarkly.bar', function () {
+          const launchDarkly = this.get('launchDarkly');
+
+          if (launchDarkly.get('bar')) {
+            return null;
+          }
+        })
+      });
+      `
+    },
+    {
+      title: 'Export variable declaration as default',
+      code: `
+      import computed from 'ember-computed';
+      import { variation } from 'ember-launch-darkly';
+
+      const Thing = Component.extend({
+        foo: computed(function() {
+          if(variation('bar')) {
+            return null;
+          }
+        })
+      });
+
+      export default Thing;
+      `,
+      output: `
+      import { default as launchDarklyService } from 'ember-service/inject';
+      import computed from 'ember-computed';
+
+
+      const Thing = Component.extend({
+        launchDarkly: launchDarklyService(),
+
+        foo: computed('launchDarkly.bar', function () {
+          const launchDarkly = this.get('launchDarkly');
+
+          if (launchDarkly.get('bar')) {
+            return null;
+          }
+        })
+      });
+
+      export default Thing;
+      `
+    },
+    {
+      title: 'Export variable declaration as member',
+      code: `
+      import computed from 'ember-computed';
+      import { variation } from 'ember-launch-darkly';
+
+      const Thing = Component.extend({
+        foo: computed(function() {
+          if(variation('bar')) {
+            return null;
+          }
+        })
+      });
+
+      export { Thing };
+      `,
+      output: `
+      import { default as launchDarklyService } from 'ember-service/inject';
+      import computed from 'ember-computed';
+
+
+      const Thing = Component.extend({
+        launchDarkly: launchDarklyService(),
+
+        foo: computed('launchDarkly.bar', function () {
+          const launchDarkly = this.get('launchDarkly');
+
+          if (launchDarkly.get('bar')) {
+            return null;
+          }
+        })
+      });
+
+      export { Thing };
+      `
+    }
+  ]
+});
+
+pluginTester({
+  plugin,
+  title: 'Variation invocation transformations',
+  snapshot: false,
+  filename: __filename,
+  tests: [
+    {
+      title: 'Base helper invocations',
+      fixture: '__fixtures__/helper-invocations/input.js',
+      outputFixture: '__fixtures__/helper-invocations/expected.js'
+    },
+    {
+      title: 'Invoke using alias',
+      code: `
+      import computed from 'ember-computed';
+      import { variation as foo } from 'ember-launch-darkly';
+
+      export default Component.extend({
+        foo: computed(function() {
+          if(foo('bar')) {
+            return null;
+          }
+        })
+      });
+      `,
+      output: `
+      import { default as launchDarklyService } from 'ember-service/inject';
+      import computed from 'ember-computed';
+
+
+      export default Component.extend({
+        launchDarkly: launchDarklyService(),
+
+        foo: computed('launchDarkly.bar', function () {
+          const launchDarkly = this.get('launchDarkly');
+
+          if (launchDarkly.get('bar')) {
+            return null;
+          }
+        })
+      });
+      `
+    }
+  ]
+});
+
+pluginTester({
+  plugin,
+  title: 'Code that should not be transformed',
+  snapshot: false,
+  tests: [
+    {
+      title: 'An Object creation that does not include a reference to the variation helper',
+      code: `
+      import Ember from 'ember';
+      import Resolver from './resolver';
+      import loadInitializers from 'ember-load-initializers';
+      import config from './config/environment';
+
+      let App;
+
+      Ember.MODEL_FACTORY_INJECTIONS = true;
+
+      App = Ember.Application.extend({
+          modulePrefix: config.modulePrefix,
+          podModulePrefix: config.podModulePrefix,
+          Resolver
+      });
+
+      loadInitializers(App, config.modulePrefix);
+
+      export default App;
+      `
+    }
+  ]
+});

--- a/package.json
+++ b/package.json
@@ -18,10 +18,13 @@
     "test": "ember try:each"
   },
   "dependencies": {
-    "ember-cli-babel": "^6.3.0"
+    "ember-cli-babel": "^6.3.0",
+    "ldclient-js": "1.1.12"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
+    "broccoli-funnel": "^2.0.0",
+    "broccoli-merge-trees": "^2.0.0",
     "ember-ajax": "^3.0.0",
     "ember-cli": "~2.14.0",
     "ember-cli-dependency-checker": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -15,16 +15,23 @@
   "scripts": {
     "build": "ember build",
     "start": "ember server",
-    "test": "ember try:each"
+    "test": "ember try:each",
+    "test-node": "./node_modules/mocha/bin/mocha --require babel-register nodetests/**/*-test.js"
   },
   "dependencies": {
     "ember-cli-babel": "^6.3.0",
     "ldclient-js": "1.1.12"
   },
   "devDependencies": {
+    "babel-core": "^6.26.0",
+    "babel-plugin-add-module-exports": "^0.2.1",
+    "babel-plugin-tester": "^4.0.0",
+    "babel-preset-es2015": "^6.24.1",
+    "babel-register": "^6.26.0",
     "broccoli-asset-rev": "^2.4.5",
     "broccoli-funnel": "^2.0.0",
     "broccoli-merge-trees": "^2.0.0",
+    "chai": "^4.1.1",
     "ember-ajax": "^3.0.0",
     "ember-cli": "~2.14.0",
     "ember-cli-dependency-checker": "^1.3.0",
@@ -41,7 +48,8 @@
     "ember-load-initializers": "^1.0.0",
     "ember-resolver": "^4.0.0",
     "ember-source": "~2.14.0",
-    "loader.js": "^4.2.3"
+    "loader.js": "^4.2.3",
+    "mocha": "^3.5.0"
   },
   "engines": {
     "node": "^4.5 || 6.* || >= 7.*"

--- a/tests/integration/helpers/variation-test.js
+++ b/tests/integration/helpers/variation-test.js
@@ -1,0 +1,17 @@
+
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('variation', 'helper:variation', {
+  integration: true
+});
+
+// Replace this with your real tests.
+test('it renders', function(assert) {
+  this.set('inputValue', '1234');
+
+  this.render(hbs`{{variation inputValue}}`);
+
+  assert.equal(this.$().text().trim(), '1234');
+});
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -276,6 +276,10 @@ assert-plus@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-0.2.0.tgz#d74e1b87e7affc0db8aadb7021f3fe48101ab234"
 
+assertion-error@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.0.2.tgz#13ca515d86206da0bac66e834dd397d87581094c"
+
 ast-types@0.9.6:
   version "0.9.6"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.6.tgz#102c9e9e9005d3e7e3829bf0c4fa24ee862ee9b9"
@@ -337,7 +341,7 @@ babel-code-frame@^6.16.0, babel-code-frame@^6.26.0:
     esutils "^2.0.2"
     js-tokens "^3.0.2"
 
-babel-core@^6.14.0, babel-core@^6.26.0:
+babel-core@^6.14.0, babel-core@^6.25.0, babel-core@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.0.tgz#af32f78b31a6fcef119c87b0fd8d9753f03a0bb8"
   dependencies:
@@ -481,6 +485,10 @@ babel-messages@^6.23.0:
   dependencies:
     babel-runtime "^6.22.0"
 
+babel-plugin-add-module-exports@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-add-module-exports/-/babel-plugin-add-module-exports-0.2.1.tgz#9ae9a1f4a8dc67f0cdec4f4aeda1e43a5ff65e25"
+
 babel-plugin-check-es2015-constants@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz#35157b101426fd2ffd3da3f75c7d1e91835bbf8a"
@@ -515,6 +523,17 @@ babel-plugin-syntax-trailing-function-commas@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz#ba0360937f8d06e40180a43fe0d5616fff532cf3"
 
+babel-plugin-tester@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-tester/-/babel-plugin-tester-4.0.0.tgz#5c05af9a175e2a1c7b3d6a195e710f1ae948a2bc"
+  dependencies:
+    babel-core "^6.25.0"
+    common-tags "^1.4.0"
+    invariant "^2.2.2"
+    lodash.merge "^4.6.0"
+    path-exists "^3.0.0"
+    strip-indent "^2.0.0"
+
 babel-plugin-transform-async-to-generator@^6.22.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz#6536e378aff6cb1d5517ac0e40eb3e9fc8d08761"
@@ -535,7 +554,7 @@ babel-plugin-transform-es2015-block-scoped-functions@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-block-scoping@^6.23.0:
+babel-plugin-transform-es2015-block-scoping@^6.23.0, babel-plugin-transform-es2015-block-scoping@^6.24.1:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz#d70f5299c1308d05c12f463813b0a09e73b1895f"
   dependencies:
@@ -545,7 +564,7 @@ babel-plugin-transform-es2015-block-scoping@^6.23.0:
     babel-types "^6.26.0"
     lodash "^4.17.4"
 
-babel-plugin-transform-es2015-classes@^6.23.0:
+babel-plugin-transform-es2015-classes@^6.23.0, babel-plugin-transform-es2015-classes@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz#5a4c58a50c9c9461e564b4b2a3bfabc97a2584db"
   dependencies:
@@ -559,33 +578,33 @@ babel-plugin-transform-es2015-classes@^6.23.0:
     babel-traverse "^6.24.1"
     babel-types "^6.24.1"
 
-babel-plugin-transform-es2015-computed-properties@^6.22.0:
+babel-plugin-transform-es2015-computed-properties@^6.22.0, babel-plugin-transform-es2015-computed-properties@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz#6fe2a8d16895d5634f4cd999b6d3480a308159b3"
   dependencies:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
-babel-plugin-transform-es2015-destructuring@^6.23.0:
+babel-plugin-transform-es2015-destructuring@^6.22.0, babel-plugin-transform-es2015-destructuring@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz#997bb1f1ab967f682d2b0876fe358d60e765c56d"
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-duplicate-keys@^6.22.0:
+babel-plugin-transform-es2015-duplicate-keys@^6.22.0, babel-plugin-transform-es2015-duplicate-keys@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz#73eb3d310ca969e3ef9ec91c53741a6f1576423e"
   dependencies:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
 
-babel-plugin-transform-es2015-for-of@^6.23.0:
+babel-plugin-transform-es2015-for-of@^6.22.0, babel-plugin-transform-es2015-for-of@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz#f47c95b2b613df1d3ecc2fdb7573623c75248691"
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-function-name@^6.22.0:
+babel-plugin-transform-es2015-function-name@^6.22.0, babel-plugin-transform-es2015-function-name@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz#834c89853bc36b1af0f3a4c5dbaa94fd8eacaa8b"
   dependencies:
@@ -616,7 +635,7 @@ babel-plugin-transform-es2015-modules-commonjs@^6.23.0, babel-plugin-transform-e
     babel-template "^6.26.0"
     babel-types "^6.26.0"
 
-babel-plugin-transform-es2015-modules-systemjs@^6.23.0:
+babel-plugin-transform-es2015-modules-systemjs@^6.23.0, babel-plugin-transform-es2015-modules-systemjs@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz#ff89a142b9119a906195f5f106ecf305d9407d23"
   dependencies:
@@ -624,7 +643,7 @@ babel-plugin-transform-es2015-modules-systemjs@^6.23.0:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
-babel-plugin-transform-es2015-modules-umd@^6.23.0:
+babel-plugin-transform-es2015-modules-umd@^6.23.0, babel-plugin-transform-es2015-modules-umd@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz#ac997e6285cd18ed6176adb607d602344ad38468"
   dependencies:
@@ -632,14 +651,14 @@ babel-plugin-transform-es2015-modules-umd@^6.23.0:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
-babel-plugin-transform-es2015-object-super@^6.22.0:
+babel-plugin-transform-es2015-object-super@^6.22.0, babel-plugin-transform-es2015-object-super@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz#24cef69ae21cb83a7f8603dad021f572eb278f8d"
   dependencies:
     babel-helper-replace-supers "^6.24.1"
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-parameters@^6.23.0:
+babel-plugin-transform-es2015-parameters@^6.23.0, babel-plugin-transform-es2015-parameters@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz#57ac351ab49caf14a97cd13b09f66fdf0a625f2b"
   dependencies:
@@ -650,7 +669,7 @@ babel-plugin-transform-es2015-parameters@^6.23.0:
     babel-traverse "^6.24.1"
     babel-types "^6.24.1"
 
-babel-plugin-transform-es2015-shorthand-properties@^6.22.0:
+babel-plugin-transform-es2015-shorthand-properties@^6.22.0, babel-plugin-transform-es2015-shorthand-properties@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz#24f875d6721c87661bbd99a4622e51f14de38aa0"
   dependencies:
@@ -663,7 +682,7 @@ babel-plugin-transform-es2015-spread@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-sticky-regex@^6.22.0:
+babel-plugin-transform-es2015-sticky-regex@^6.22.0, babel-plugin-transform-es2015-sticky-regex@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz#00c1cdb1aca71112cdf0cf6126c2ed6b457ccdbc"
   dependencies:
@@ -677,13 +696,13 @@ babel-plugin-transform-es2015-template-literals@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-typeof-symbol@^6.23.0:
+babel-plugin-transform-es2015-typeof-symbol@^6.22.0, babel-plugin-transform-es2015-typeof-symbol@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz#dec09f1cddff94b52ac73d505c84df59dcceb372"
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-unicode-regex@^6.22.0:
+babel-plugin-transform-es2015-unicode-regex@^6.22.0, babel-plugin-transform-es2015-unicode-regex@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz#d38b12f42ea7323f729387f18a7c5ae1faeb35e9"
   dependencies:
@@ -699,7 +718,7 @@ babel-plugin-transform-exponentiation-operator@^6.22.0:
     babel-plugin-syntax-exponentiation-operator "^6.8.0"
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-regenerator@^6.22.0:
+babel-plugin-transform-regenerator@^6.22.0, babel-plugin-transform-regenerator@^6.24.1:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz#e0703696fbde27f0a3efcacf8b4dca2f7b3a8f2f"
   dependencies:
@@ -754,6 +773,35 @@ babel-preset-env@^1.5.1:
     browserslist "^2.1.2"
     invariant "^2.2.2"
     semver "^5.3.0"
+
+babel-preset-es2015@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz#d44050d6bc2c9feea702aaf38d727a0210538939"
+  dependencies:
+    babel-plugin-check-es2015-constants "^6.22.0"
+    babel-plugin-transform-es2015-arrow-functions "^6.22.0"
+    babel-plugin-transform-es2015-block-scoped-functions "^6.22.0"
+    babel-plugin-transform-es2015-block-scoping "^6.24.1"
+    babel-plugin-transform-es2015-classes "^6.24.1"
+    babel-plugin-transform-es2015-computed-properties "^6.24.1"
+    babel-plugin-transform-es2015-destructuring "^6.22.0"
+    babel-plugin-transform-es2015-duplicate-keys "^6.24.1"
+    babel-plugin-transform-es2015-for-of "^6.22.0"
+    babel-plugin-transform-es2015-function-name "^6.24.1"
+    babel-plugin-transform-es2015-literals "^6.22.0"
+    babel-plugin-transform-es2015-modules-amd "^6.24.1"
+    babel-plugin-transform-es2015-modules-commonjs "^6.24.1"
+    babel-plugin-transform-es2015-modules-systemjs "^6.24.1"
+    babel-plugin-transform-es2015-modules-umd "^6.24.1"
+    babel-plugin-transform-es2015-object-super "^6.24.1"
+    babel-plugin-transform-es2015-parameters "^6.24.1"
+    babel-plugin-transform-es2015-shorthand-properties "^6.24.1"
+    babel-plugin-transform-es2015-spread "^6.22.0"
+    babel-plugin-transform-es2015-sticky-regex "^6.24.1"
+    babel-plugin-transform-es2015-template-literals "^6.22.0"
+    babel-plugin-transform-es2015-typeof-symbol "^6.22.0"
+    babel-plugin-transform-es2015-unicode-regex "^6.24.1"
+    babel-plugin-transform-regenerator "^6.24.1"
 
 babel-register@^6.26.0:
   version "6.26.0"
@@ -1240,6 +1288,10 @@ broccoli-uglify-sourcemap@^1.0.0:
     uglify-js "^2.7.0"
     walk-sync "^0.1.3"
 
+browser-stdout@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.0.tgz#f351d32969d32fa5d7a5567154263d928ae3bd1f"
+
 browserslist@^2.1.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-2.3.3.tgz#2b0cabc4d28489f682598605858a0782f14b154c"
@@ -1323,6 +1375,17 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
+chai@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-4.1.1.tgz#66e21279e6f3c6415ff8231878227900e2171b39"
+  dependencies:
+    assertion-error "^1.0.1"
+    check-error "^1.0.1"
+    deep-eql "^2.0.1"
+    get-func-name "^2.0.0"
+    pathval "^1.0.0"
+    type-detect "^4.0.0"
+
 chalk@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-0.5.1.tgz#663b3a648b68b55d04690d49167aa837858f2174"
@@ -1356,6 +1419,10 @@ charm@^1.0.0:
   resolved "https://registry.yarnpkg.com/charm/-/charm-1.0.2.tgz#8add367153a6d9a581331052c4090991da995e35"
   dependencies:
     inherits "^2.0.1"
+
+check-error@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
 
 chokidar@1.6.1:
   version "1.6.1"
@@ -1474,15 +1541,17 @@ commander@2.8.x:
   dependencies:
     graceful-readlink ">= 1.0.0"
 
-commander@2.9.0:
+commander@2.9.0, commander@^2.6.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
     graceful-readlink ">= 1.0.0"
 
-commander@^2.6.0:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
+common-tags@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.4.0.tgz#1187be4f3d4cf0c0427d43f74eef1f73501614c0"
+  dependencies:
+    babel-runtime "^6.18.0"
 
 component-bind@1.0.0:
   version "1.0.0"
@@ -1662,6 +1731,12 @@ decamelize@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
+deep-eql@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-2.0.2.tgz#b1bac06e56f0a76777686d50c9feb75c2ed7679a"
+  dependencies:
+    type-detect "^3.0.0"
+
 deep-extend@~0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.2.tgz#48b699c27e334bf89f10892be432f6e4c7d34a7f"
@@ -1709,6 +1784,10 @@ detect-indent@^4.0.0:
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-4.0.0.tgz#f76d064352cdf43a1cb6ce619c4ee3a9475de208"
   dependencies:
     repeating "^2.0.0"
+
+diff@3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
 
 diff@^3.2.0:
   version "3.3.0"
@@ -2749,6 +2828,10 @@ get-caller-file@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
 
+get-func-name@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
+
 get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
@@ -2840,6 +2923,10 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6,
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
 
+growl@1.9.2:
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/growl/-/growl-1.9.2.tgz#0ea7743715db8d8de2c5ede1775e1b45ac85c02f"
+
 growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
@@ -2892,6 +2979,10 @@ has-binary@0.1.7:
 has-cors@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/has-cors/-/has-cors-1.1.0.tgz#5e474793f7ea9843d1bb99c23eef49ff126fff39"
+
+has-flag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
 
 has-flag@^2.0.0:
   version "2.0.0"
@@ -3427,6 +3518,10 @@ lodash._basecopy@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz#8da0e6a876cf344c0ad8a54882111dd3c5c7ca36"
 
+lodash._basecreate@^3.0.0:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz#1bc661614daa7fc311b7d03bf16806a0213cf821"
+
 lodash._basecreate@~2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/lodash._basecreate/-/lodash._basecreate-2.3.0.tgz#9b88a86a4dcff7b7f3c61d83a2fcfc0671ec9de0"
@@ -3565,6 +3660,14 @@ lodash.bind@~2.3.0:
 lodash.clonedeep@^4.4.1:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
+
+lodash.create@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.create/-/lodash.create-3.1.1.tgz#d7f2849f0dbda7e04682bb8cd72ab022461debe7"
+  dependencies:
+    lodash._baseassign "^3.0.0"
+    lodash._basecreate "^3.0.0"
+    lodash._isiterateecall "^3.0.0"
 
 lodash.debounce@^3.1.1:
   version "3.1.1"
@@ -3883,7 +3986,7 @@ minimist@^1.1.1, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
-mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1:
+mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
@@ -3892,6 +3995,22 @@ mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1:
 mktemp@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/mktemp/-/mktemp-0.4.0.tgz#6d0515611c8a8c84e484aa2000129b98e981ff0b"
+
+mocha@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-3.5.0.tgz#1328567d2717f997030f8006234bce9b8cd72465"
+  dependencies:
+    browser-stdout "1.3.0"
+    commander "2.9.0"
+    debug "2.6.8"
+    diff "3.2.0"
+    escape-string-regexp "1.0.5"
+    glob "7.1.1"
+    growl "1.9.2"
+    json3 "3.3.2"
+    lodash.create "3.1.1"
+    mkdirp "0.5.1"
+    supports-color "3.1.2"
 
 morgan@^1.8.1:
   version "1.8.2"
@@ -4195,6 +4314,10 @@ path-posix@^1.0.0:
 path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
+
+pathval@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
 
 performance-now@^0.2.0:
   version "0.2.0"
@@ -4884,6 +5007,10 @@ strip-eof@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
 
+strip-indent@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
+
 strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
@@ -4897,6 +5024,12 @@ sum-up@^1.0.1:
   resolved "https://registry.yarnpkg.com/sum-up/-/sum-up-1.0.3.tgz#1c661f667057f63bcb7875aa1438bc162525156e"
   dependencies:
     chalk "^1.0.0"
+
+supports-color@3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
+  dependencies:
+    has-flag "^1.0.0"
 
 supports-color@^0.2.0:
   version "0.2.0"
@@ -5081,6 +5214,14 @@ type-check@~0.3.2:
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
   dependencies:
     prelude-ls "~1.1.2"
+
+type-detect@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-3.0.0.tgz#46d0cc8553abb7b13a352b0d6dea2fd58f2d9b55"
+
+type-detect@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.3.tgz#0e3f2670b44099b0b46c284d136a7ef49c74c2ea"
 
 type-is@~1.6.15:
   version "1.6.15"

--- a/yarn.lock
+++ b/yarn.lock
@@ -82,6 +82,10 @@
   dependencies:
     "@glimmer/util" "^0.22.3"
 
+Base64@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/Base64/-/Base64-1.0.0.tgz#b6b73ee342ce64bf66d6003a4536683bf8a349b5"
+
 abbrev@1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.0.tgz#d0554c2256636e2f56e7c2e5ad183f859428d81f"
@@ -1059,6 +1063,25 @@ broccoli-funnel-reducer@^1.0.0:
 broccoli-funnel@^1.0.0, broccoli-funnel@^1.0.1, broccoli-funnel@^1.0.6, broccoli-funnel@^1.1.0, broccoli-funnel@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz#cddc3afc5ff1685a8023488fff74ce6fb5a51296"
+  dependencies:
+    array-equal "^1.0.0"
+    blank-object "^1.0.1"
+    broccoli-plugin "^1.3.0"
+    debug "^2.2.0"
+    exists-sync "0.0.4"
+    fast-ordered-set "^1.0.0"
+    fs-tree-diff "^0.5.3"
+    heimdalljs "^0.2.0"
+    minimatch "^3.0.0"
+    mkdirp "^0.5.0"
+    path-posix "^1.0.0"
+    rimraf "^2.4.3"
+    symlink-or-copy "^1.0.0"
+    walk-sync "^0.3.1"
+
+broccoli-funnel@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-2.0.0.tgz#12bec71c34118eedb0cc1d9a3a41df97b6b0c73b"
   dependencies:
     array-equal "^1.0.0"
     blank-object "^1.0.1"
@@ -2235,7 +2258,7 @@ escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
 
-escape-string-regexp@^1.0.0, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.3, escape-string-regexp@^1.0.5:
+escape-string-regexp@1.0.5, escape-string-regexp@^1.0.0, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.3, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
@@ -2757,7 +2780,7 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
-glob@7.1.1:
+glob@7.1.1, glob@^7.0.0, glob@^7.0.3, glob@^7.0.4, glob@^7.0.5:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
   dependencies:
@@ -2775,17 +2798,6 @@ glob@^5.0.10:
     inflight "^1.0.4"
     inherits "2"
     minimatch "2 || 3"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.4, glob@^7.0.5:
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
@@ -3353,6 +3365,13 @@ lazy-cache@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-1.0.4.tgz#a1d78fc3a50474cb80845d3b3b6e1da49a446e8e"
 
+ldclient-js@1.1.12:
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/ldclient-js/-/ldclient-js-1.1.12.tgz#06ea0dc2326bd84116f0c6674ccd8ff7a83e7d8d"
+  dependencies:
+    Base64 "1.0.0"
+    escape-string-regexp "1.0.5"
+
 leek@0.0.24:
   version "0.0.24"
   resolved "https://registry.yarnpkg.com/leek/-/leek-0.0.24.tgz#e400e57f0e60d8ef2bd4d068dc428a54345dbcda"
@@ -3856,17 +3875,13 @@ mime@^1.2.11:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@0.0.8:
+minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
 minimist@^1.1.1, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
-
-minimist@~0.0.1:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
 mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1:
   version "0.5.1"
@@ -4784,11 +4799,7 @@ spawn-sync@^1.0.15:
     concat-stream "^1.4.7"
     os-shim "^0.1.2"
 
-sprintf-js@^1.0.3:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.1.tgz#36be78320afe5801f6cea3ee78b6e5aab940ea0c"
-
-sprintf-js@~1.0.2:
+sprintf-js@^1.0.3, sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 


### PR DESCRIPTION
Approaching this from a README Driven Development perspective. View the [README here](https://github.com/kayako/ember-launch-darkly/blob/master/README.md).

## TODO
- [ ] Support config options
  - [x] clientSideId
  - [x] local
  - [x] featureFlags
  - [ ] secureMode
- [x] LD service
  - [x] `initialize()`
  - [x] `identify()`
  - [ ] `track`
- [x] `variation` template helper
- [x] `variation` js helper
  - [x] Babel transform
- [ ] computedVariation computed macro
- [x] Support local feature flags
  - [x] Make available on `window.ld`
  - [x] Add helper functions
  - [x] Helper functions recompute `variation` helper
- [x] Testing support
  - [x] Ensure local service is used for test environment
  - [x] Acceptance test helper
- [ ] Install deps
  - [x] Install LD client
  - [ ] Event polyfill
  - [ ]  Inject CSP entry if needed (or update README to inform user they need to)

## Notes and Thoughts

- ~Potentially store `_allFlags` in the remote service which would give parallelism to the local service~ ✅ 
- ~Dynamically create CP's on local service too?~ ✅ 
- ~Once we've done that maybe there doesn't need to be a remote and local service~
- ~Have removed the ability to specify the `defaultValue` which is maybe not great. Also, the helper function in the local service that sets the variation reuses `variation(key, value)` which means that if we did want to implement the default value this would break. Should consider renaming to `setVariation` or something~