### PR TITLE
Fix bug where vendorTree is undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,6 @@ module.exports = {
       files: ['ldclient.js'],
     });
 
-    return new MergeTrees([vendorTree, ldTree]);
+    return vendorTree ? new MergeTrees([vendorTree, ldTree]) : ldTree;
   }
 };


### PR DESCRIPTION
It turns out that when running `ember release`, the vendor folder is
removed from the packaged module before pushing to npm. This causes
`vendorTree` that is passed in to `treeForVendor` to be undefined which
blows up.

This just checks for this occurance.