### PR TITLE
Pass flag key as default value

### DIFF
--- a/addon/services/launch-darkly-remote.js
+++ b/addon/services/launch-darkly-remote.js
@@ -66,9 +66,10 @@ export default Service.extend({
   },
 
   variation(key) {
-    let value = this.get('_client').variation(key, NON_EXISTANT_FLAG_VALUE);
+    let nonExistantFlagValue = `${NON_EXISTANT_FLAG_VALUE}: ${key}`;
+    let value = this.get('_client').variation(key, nonExistantFlagValue);
 
-    if (value === NON_EXISTANT_FLAG_VALUE) {
+    if (value === nonExistantFlagValue) {
       warn(`Feature flag with key '${key}' has not been defined. Returning default value of '${DEFAULT_FLAG_VALUE}'`, false, { id: 'ember-launch-darkly.feature-flag-not-defined' });
 
       return DEFAULT_FLAG_VALUE;


### PR DESCRIPTION
This is used so that if the default value is returned it means that the
flag for that key is not defined. This then means that we can see the
flag name in the dev console for that request. Without doing this, it's
impossible to see what the unknown flag key is in the dev console.

This is a bit of a workaround until LD improve their dev console.